### PR TITLE
Add docker stuff so that the code can be run in a container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8-slim
+
+RUN apt-get update \
+    && apt install cron -y
+
+# run on the first minute of every hour
+RUN echo '1 * * * * python /src/ROF/rof_config.py >> /var/log/cron.log 2>&1' > /etc/cron.d/rof-cron && \
+    chmod 0644 /etc/cron.d/rof-cron && \
+    crontab /etc/cron.d/rof-cron && \
+    touch /var/log/cron.log
+
+# Create source and output directory
+RUN mkdir -p /src /data /rof_maps
+
+# copy source files and deps list
+COPY requirements.txt /src
+# install deps
+RUN python -m pip install -r /src/requirements.txt
+COPY ./ROF /src/ROF/
+
+WORKDIR /src/ROF
+
+# start cron and log to docker logs
+ENTRYPOINT ["cron && tail -f /var/log/cron.log"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,19 @@
+
+.PHONY: build deploy help
+
+help:
+	    @echo "Makefile commands:"
+	    @echo "\tbuild - Build the image(s)"
+	    @echo "\tdeploy - Put the service(s) up"
+	    @echo "\tdown - Pull the service(s) down"
+
+.DEFAULT_GOAL := help
+
+build:
+	@docker-compose -f build/docker-compose.yml build
+
+deploy:
+	@docker-compose -f deploy/docker-compose.yml up -d
+
+down:
+	@docker-compose -f deploy/docker-compose.yml down

--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -1,0 +1,5 @@
+# Build
+
+```shell
+docker-compose build
+```

--- a/docker/build/docker-compose.yml
+++ b/docker/build/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  rof:
+    image: rof
+    build:
+      context: ../../
+      dockerfile: ./docker/Dockerfile

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  rof:
+    image: rof
+    restart: always
+    working_dir: /src/ROF
+    entrypoint: "python rof_config.py"
+    volumes:
+      - <somewhere-local>/data:/data
+      - <somewhere-local>/output:/rof_maps


### PR DESCRIPTION
Add docker related files (`Dockerfile` and `docker-compose.yml`) to support running the ROF code in a container.

## Additions

- `Dockerfile` that copies and runs the code in a container
- `docker-compose.yml` files for building and deploying the container
- `Makefile` for simplifying the process of building and deploying

## Notes

- In the future, it would be great to use the ROF code via a CLI. First, using standard command line flags to supply args, but also sidestep passing all the args via the command line with a config file. This functionality would make it really easy to deploy different configurations of the ROF code in a containerized environment.
